### PR TITLE
Add Email Support for Registrations and Extend Unit/Integration Tests

### DIFF
--- a/src/Example.Web/Example.Web.csproj
+++ b/src/Example.Web/Example.Web.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Adliance.Buddy.Crypto" Version="8.0.0.5" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Example.Web/Factories/ViewModels/Home/IndexViewModelFactory.cs
+++ b/src/Example.Web/Factories/ViewModels/Home/IndexViewModelFactory.cs
@@ -1,3 +1,4 @@
+using Adliance.Buddy.Crypto;
 using Example.Web.Models.Database;
 using Example.Web.ViewModels.Home;
 
@@ -12,17 +13,47 @@ public class IndexViewModelFactory(ILogger<IndexViewModelFactory> logger, Db db)
 
     public async Task<IndexViewModel> HandleRegistrationAsync(IndexViewModel viewModel)
     {
-        var registration = new Registration
-        {
-            FirstName = viewModel.FirstName,
-            LastName = viewModel.LastName,
-            CreatedUtc = DateTime.UtcNow
-        };
-        db.Registrations.Add(registration);
-        await db.SaveChangesAsync();
-        viewModel.ShowSuccessMessage = true;
 
-        logger.LogInformation($"Registration of {viewModel.FirstName} {viewModel.LastName} stored in database with ID {registration.Id}.");
+        if (EmailExists(viewModel.EMail))
+        {
+            viewModel.ShowErrorMessage = true;
+
+            logger.LogInformation($"Registration of {viewModel.FirstName} {viewModel.LastName} ({viewModel.EMail}) failed.");
+        }
+        else
+        {
+            var hash = Crypto.Hash(viewModel.EMail, out var salt);
+
+            var registration = new Registration
+            {
+                FirstName = viewModel.FirstName,
+                LastName = viewModel.LastName,
+                CreatedUtc = DateTime.UtcNow,
+                EmailHash = hash,
+                EmailHashSalt = salt
+            };
+
+            db.Registrations.Add(registration);
+            await db.SaveChangesAsync();
+            viewModel.ShowSuccessMessage = true;
+
+            logger.LogInformation($"Registration of {viewModel.FirstName} {viewModel.LastName} ({viewModel.EMail}) stored in database with ID {registration.Id}.");
+        }
+
         return viewModel;
+    }
+
+    private bool EmailExists(string email)
+    {
+        foreach (var reg in db.Registrations.ToList())
+        {
+            var hash = Crypto.Hash(email, reg.EmailHashSalt);
+
+            if (hash.Equals(reg.EmailHash))
+            {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/Example.Web/Migrations/20241010112822_AddEmailHash.Designer.cs
+++ b/src/Example.Web/Migrations/20241010112822_AddEmailHash.Designer.cs
@@ -4,6 +4,7 @@ using Example.Web.Models.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Example.Web.Migrations
 {
     [DbContext(typeof(Db))]
-    partial class DbModelSnapshot : ModelSnapshot
+    [Migration("20241010112822_AddEmailHash")]
+    partial class AddEmailHash
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -32,10 +35,6 @@ namespace Example.Web.Migrations
                         .HasColumnType("datetime2");
 
                     b.Property<string>("EmailHash")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("EmailHashSalt")
                         .IsRequired()
                         .HasColumnType("nvarchar(max)");
 

--- a/src/Example.Web/Migrations/20241010112822_AddEmailHash.cs
+++ b/src/Example.Web/Migrations/20241010112822_AddEmailHash.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Example.Web.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEmailHash : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "EmailHash",
+                table: "Registrations",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "EmailHash",
+                table: "Registrations");
+        }
+    }
+}

--- a/src/Example.Web/Migrations/20241010113048_AddEmailHashSalt.Designer.cs
+++ b/src/Example.Web/Migrations/20241010113048_AddEmailHashSalt.Designer.cs
@@ -4,6 +4,7 @@ using Example.Web.Models.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Example.Web.Migrations
 {
     [DbContext(typeof(Db))]
-    partial class DbModelSnapshot : ModelSnapshot
+    [Migration("20241010113048_AddEmailHashSalt")]
+    partial class AddEmailHashSalt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Example.Web/Migrations/20241010113048_AddEmailHashSalt.cs
+++ b/src/Example.Web/Migrations/20241010113048_AddEmailHashSalt.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Example.Web.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEmailHashSalt : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "EmailHashSalt",
+                table: "Registrations",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "EmailHashSalt",
+                table: "Registrations");
+        }
+    }
+}

--- a/src/Example.Web/Models/Database/Registration.cs
+++ b/src/Example.Web/Models/Database/Registration.cs
@@ -6,4 +6,6 @@ public class Registration
     public string FirstName { get; set; } = "";
     public string LastName { get; set; } = "";
     public DateTime CreatedUtc { get; set; }
+    public string EmailHash { get; set; } = "";
+    public string EmailHashSalt { get; set; } = "";
 }

--- a/src/Example.Web/ViewModels/Home/IndexViewModel.cs
+++ b/src/Example.Web/ViewModels/Home/IndexViewModel.cs
@@ -6,5 +6,8 @@ public class IndexViewModel
 {
     [Required] public string FirstName { get; set; } = "";
     [Required] public string LastName { get; set; } = "";
+    [Required] public string EMail { get; set; } = "";
+
     public bool ShowSuccessMessage { get; set; }
+    public bool ShowErrorMessage { get; set; }
 }

--- a/src/Example.Web/Views/Home/Index.cshtml
+++ b/src/Example.Web/Views/Home/Index.cshtml
@@ -11,6 +11,13 @@
     </div>
 }
 
+@if (Model.ShowErrorMessage)
+{
+    <div class="alert alert-danger mt-5 mb-3" role="alert">
+        Entered email already exists in database.
+    </div>
+}
+
 <form method="post">
     <div class="form-group">
         <label asp-for="FirstName">Your first name:</label>
@@ -21,6 +28,12 @@
         <label asp-for="LastName">Your last name:</label>
         <input asp-for="LastName" class="form-control" placeholder="eg. Jobs">
         <span asp-validation-for="LastName"></span>
+    </div>
+
+    <div class="form-group mt-3">
+            <label asp-for="EMail">Your email address:</label>
+            <input asp-for="EMail" class="form-control" placeholder="steve.jobs@example.com">
+            <span asp-validation-for="EMail"></span>
     </div>
 
     <button type="submit" class="btn btn-primary mt-3">Submit</button>

--- a/test/Example.Web.Tests/Controllers/HomeControllerTests.cs
+++ b/test/Example.Web.Tests/Controllers/HomeControllerTests.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
+using Adliance.Buddy.Crypto;
 
 namespace Example.Web.Tests.Controllers;
 
@@ -33,19 +34,186 @@ public class HomeControllerTests : IClassFixture<WebApplicationFactory<Program>>
     [Fact]
     public async Task Post_Will_Store_Registration_In_Database()
     {
+        var firstname = "Some first name";
+        var lastname = "Some last name";
+        var email = "Some email";
+
         // send a raw POST here for true integration test
+        using var httpClient = _factory.CreateClient();
+        var response = await httpClient.PostAsync("/", new FormUrlEncodedContent(new KeyValuePair<string, string>[]
+        {
+            new("FirstName", firstname), new("LastName", lastname), new("Email", email)
+        }));
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        Assert.Single(await _db.Registrations.ToListAsync());
+
+        var registration = await _db.Registrations.SingleAsync();
+        Assert.Equal(firstname, registration.FirstName);
+        Assert.Equal(lastname, registration.LastName);
+
+        var emailHashed = Crypto.Hash(email, registration.EmailHashSalt);
+        Assert.Equal(emailHashed, registration.EmailHash);
+    }
+
+    [Fact]
+    public async Task Same_Names_Different_Emails_Insertion_In_Database()
+    {
+        var firstname = "Some first name";
+        var lastname = "Some last name";
+        List<string> emails = ["email1@example.com","email2@example.com", "email3@example.com"];
+
+        // send a raw POST here for true integration test
+        using var httpClient = _factory.CreateClient();
+
+        foreach (var email in emails)
+        {
+            var response = await httpClient.PostAsync("/", new FormUrlEncodedContent(new KeyValuePair<string, string>[]
+            {
+                new("FirstName", firstname), new("LastName", lastname), new("Email", email)
+            }));
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        // 3 entries in database
+        Assert.Equal((await _db.Registrations.ToListAsync()).Count, emails.Count);
+
+        var registrations = await _db.Registrations.ToListAsync();
+
+        for (var i = 0; i < registrations.Count; i++)
+        {
+
+            Assert.Equal(firstname, registrations[i].FirstName);
+            Assert.Equal(lastname, registrations[i].LastName);
+
+            var emailHashed = Crypto.Hash(emails[i], registrations[i].EmailHashSalt);
+            Assert.Equal(emailHashed, registrations[i].EmailHash);
+        }
+    }
+
+    [Fact]
+    public async Task Different_Names_Different_Emails_Insertion_In_Database()
+    {
+        var firstnames = new[] { "John", "Emma", "Liam" };
+        var lastnames = new[] { "Doe", "Smith", "Johnson" };
+        var emails = new[] {"email1@example.com","email2@example.com", "email3@example.com"};
+
+        // send a raw POST here for true integration test
+        using var httpClient = _factory.CreateClient();
+
+        for (var i = 0; i < firstnames.Length; i++)
+        {
+            var response = await httpClient.PostAsync("/", new FormUrlEncodedContent(new KeyValuePair<string, string>[]
+            {
+                new("FirstName", firstnames[i]), new("LastName", lastnames[i]), new("Email", emails[i])
+            }));
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        // 3 entries in database
+        Assert.Equal((await _db.Registrations.ToListAsync()).Count, emails.Length);
+
+        var registrations = await _db.Registrations.ToListAsync();
+
+        for (var i = 0; i < registrations.Count; i++)
+        {
+            Assert.Equal(firstnames[i], registrations[i].FirstName);
+            Assert.Equal(lastnames[i], registrations[i].LastName);
+
+            var emailHashed = Crypto.Hash(emails[i], registrations[i].EmailHashSalt);
+            Assert.Equal(emailHashed, registrations[i].EmailHash);
+        }
+    }
+
+    [Fact]
+    public async Task Duplicate_Emails_Insertion_In_Database()
+    {
+        var firstname = "Some first name";
+        var lastname = "Some last name";
+        var email = "Some email";
+
+        // send a raw POST here for true integration test
+        using var httpClient = _factory.CreateClient();
+        var response = await httpClient.PostAsync("/", new FormUrlEncodedContent(new KeyValuePair<string, string>[]
+        {
+            new("FirstName", firstname), new("LastName", lastname), new("Email", email)
+        }));
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        // one entry in database
+        Assert.Single(await _db.Registrations.ToListAsync());
+
+        var registration = await _db.Registrations.SingleAsync();
+        Assert.Equal(firstname, registration.FirstName);
+        Assert.Equal(lastname, registration.LastName);
+
+        var emailHashed = Crypto.Hash(email, registration.EmailHashSalt);
+        Assert.Equal(emailHashed, registration.EmailHash);
+
+        // try to insert same entry again.
+        response = await httpClient.PostAsync("/", new FormUrlEncodedContent(new KeyValuePair<string, string>[]
+        {
+            new("FirstName", firstname), new("LastName", lastname), new("Email", email)
+        }));
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        // still only one entry - no duplicates
+        Assert.Single(await _db.Registrations.ToListAsync());
+    }
+
+    [Fact]
+    public async Task Missing_Required_Firstname_Field_Insertion_In_Database()
+    {
+        var firstname = "Some first name";
+        var lastname = "Some last name";
+        var email = "Some email";
 
         using var httpClient = _factory.CreateClient();
         var response = await httpClient.PostAsync("/", new FormUrlEncodedContent(new KeyValuePair<string, string>[]
         {
-            new("FirstName", "Some first name"), new("LastName", "Some last name")
+            new("LastName", lastname), new("Email", email)
         }));
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        // nothing in database
-        Assert.Single(await _db.Registrations.ToListAsync());
-        var registration = await _db.Registrations.SingleAsync();
-        Assert.Equal("Some first name", registration.FirstName);
-        Assert.Equal("Some last name", registration.LastName);
+        // nothing was added, as firstname is required
+        Assert.Empty(await _db.Registrations.ToListAsync());
+    }
+
+    [Fact]
+    public async Task Missing_Required_Lastname_Field_Insertion_In_Database()
+    {
+        var firstname = "Some first name";
+        var lastname = "Some last name";
+        var email = "Some email";
+
+        using var httpClient = _factory.CreateClient();
+        var response = await httpClient.PostAsync("/", new FormUrlEncodedContent(new KeyValuePair<string, string>[]
+        {
+            new("FirstName", firstname), new("Email", email)
+        }));
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        // nothing was added, as lastname is required
+        Assert.Empty(await _db.Registrations.ToListAsync());
+    }
+
+    [Fact]
+    public async Task Missing_Required_Email_Field_Insertion_In_Database()
+    {
+        var firstname = "Some first name";
+        var lastname = "Some last name";
+        var email = "Some email";
+
+        using var httpClient = _factory.CreateClient();
+        var response = await httpClient.PostAsync("/", new FormUrlEncodedContent(new KeyValuePair<string, string>[]
+        {
+            new("FirstName", lastname), new("LastName", lastname)
+        }));
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        // nothing was added, as email is required
+        Assert.Empty(await _db.Registrations.ToListAsync());
     }
 }

--- a/test/Example.Web.Tests/Example.Web.Tests.csproj
+++ b/test/Example.Web.Tests/Example.Web.Tests.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Adliance.Buddy.CodeStyle" Version="8.0.0.8"/>
+    <PackageReference Include="Adliance.Buddy.Crypto" Version="8.0.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="xunit" Version="2.9.2" />


### PR DESCRIPTION
The registration form now includes a field for entering the email address. 
The system checks for duplicates of email adresses and informs the user, if the entered email adress exists already, or that the submission was successfull.
In addition, tests were added, covering the added functionality.